### PR TITLE
Fix pagination initialization size to one page

### DIFF
--- a/metka/src/main/webapp/resources/js/modules/pagination.js
+++ b/metka/src/main/webapp/resources/js/modules/pagination.js
@@ -36,7 +36,7 @@ define(function (require) {
             //it doesn't matter how many pages we show initially as we almost immediately
             //trigger redraw within containerField.js with correct rows and perPage values
             $paging.bootpag({
-                total: 5,
+                total: 1,
                 page: 1,
                 maxVisible: 5,
                 leaps: true,


### PR DESCRIPTION
Init paging with 1 page. If element where we put paging is empty paging is never updated, so it needs to be initialized with only 1 page.