### PR TITLE
Simple searches should use DEFAULT language

### DIFF
--- a/metka/src/main/webapp/resources/js/modules/pages/binder.js
+++ b/metka/src/main/webapp/resources/js/modules/pages/binder.js
@@ -53,7 +53,7 @@ define(function (require) {
                 key: 'findBinderDescription',
                 rename: 'description',
                 exactValue: true
-            }], 'pages');
+            }], 'pages', 'DEFAULT');
 
         function view(requestOptions) {
             require('./../revisionModal')(options, requestOptions, 'BINDER_PAGE', pagesSearch.search, 'pages');

--- a/metka/src/main/webapp/resources/js/modules/pages/publication.js
+++ b/metka/src/main/webapp/resources/js/modules/pages/publication.js
@@ -89,7 +89,7 @@ define(function (require) {
                     key: 'savedBy',
                     rename: 'state.saved.user'
                 }
-            ], 'publicationresults');
+            ], 'publicationresults', 'DEFAULT');
 
 
             require('./../server')('conf', {

--- a/metka/src/main/webapp/resources/js/modules/pages/series.js
+++ b/metka/src/main/webapp/resources/js/modules/pages/series.js
@@ -47,7 +47,7 @@ define(function (require) {
                     exactValue: true
                 },
                 'seriesname'
-            ], 'seriesresults');
+            ], 'seriesresults', 'DEFAULT');
 
             $.extend(options, {
                 header: MetkaJS.L10N.get('type.SERIES.search'),

--- a/metka/src/main/webapp/resources/js/modules/pages/study.js
+++ b/metka/src/main/webapp/resources/js/modules/pages/study.js
@@ -49,7 +49,7 @@ define(function (require) {
                     rename: 'studyid',
                     exactValue: true
                 }
-            ], 'studyerrors', 'error');
+            ], 'studyerrors', 'DEFAULT', 'error');
 
             function viewError(requestOptions) {
                 require('./../revisionModal')(options, requestOptions, 'STUDY_ERROR', errorSearch.search, 'studyerrors');
@@ -158,7 +158,7 @@ define(function (require) {
                             key: 'collector',
                             rename: 'collectors.author'
                         }
-                    ].concat(importFromConfiguration), 'studyresults');
+                    ].concat(importFromConfiguration), 'studyresults', 'DEFAULT');
 
                     if (resultParser(response.result).getResult() === 'CONFIGURATION_FOUND') {
                         $.extend(true, options, {

--- a/metka/src/main/webapp/resources/js/modules/pages/study_variables.js
+++ b/metka/src/main/webapp/resources/js/modules/pages/study_variables.js
@@ -316,7 +316,7 @@ define(function (require) {
                                     "title": MetkaJS.L10N.get('general.buttons.search'),
                                     "create": function() {
                                         this.click(function() {
-                                            require('./../searchRequestSearch')(options, variablesSearchOptions, 'variableslist', 'variables').search();
+                                            require('./../searchRequestSearch')(options, variablesSearchOptions, 'variableslist', 'DEFAULT', 'variables').search();
                                         });
                                     }
                                 }
@@ -415,7 +415,7 @@ define(function (require) {
                                     "title": MetkaJS.L10N.get('general.buttons.search'),
                                     "create": function() {
                                         this.click(function() {
-                                            require('./../searchRequestSearch')(options, variableSearchOptions, 'variablelist', 'variable').search();
+                                            require('./../searchRequestSearch')(options, variableSearchOptions, 'variablelist', 'DEFAULT', 'variable').search();
                                         });
                                     }
                                 }

--- a/metka/src/main/webapp/resources/js/modules/searchRequest.js
+++ b/metka/src/main/webapp/resources/js/modules/searchRequest.js
@@ -29,7 +29,7 @@
 define(function(require) {
     'use strict';
 
-    return function(options, requestConf, prefix) {
+    return function(options, requestConf, lang, prefix) {
         var data = require('./data')(options);
         if (typeof requestConf === 'function') {
             return requestConf();
@@ -94,6 +94,9 @@ define(function(require) {
                     requestData.values[searchOptions.rename || key] = value;
                 }
             });
+            if(lang) {
+                requestData.values['key.language'] = lang;
+            }
             return requestData;
         }
         throw 'Illegal search request';

--- a/metka/src/main/webapp/resources/js/modules/searchRequestSearch.js
+++ b/metka/src/main/webapp/resources/js/modules/searchRequestSearch.js
@@ -29,11 +29,11 @@
 define(function(require) {
     'use strict';
 
-    return function(options, searchOptions, resultFieldKey, prefix) {
+    return function(options, searchOptions, resultFieldKey, lang, prefix) {
         return {
             search: function() {
                 require('./server')('searchAjax', {
-                    data: JSON.stringify(require('./searchRequest')(options, searchOptions, prefix)),
+                    data: JSON.stringify(require('./searchRequest')(options, searchOptions, lang, prefix)),
                     success: function(response) {
                         require('./updateSearchResultContainer')(options, response, resultFieldKey);
                     }


### PR DESCRIPTION
Fix searchRequest, searchRequestSearch and simple searches on pages to search using DEFAULT language.

Other languages can be searched using expert-search.