### PR TITLE
fixedOrder: true for searchresults missing them, minor publication.js cleanup

### DIFF
--- a/metka/src/main/webapp/resources/js/modules/pages/publication.js
+++ b/metka/src/main/webapp/resources/js/modules/pages/publication.js
@@ -399,11 +399,6 @@ define(function (require) {
                                         target: "publicationresults",
                                         valuePath: "publicationtitle"
                                     },
-                                    publicationresultsstate_ref: {
-                                        type: "DEPENDENCY",
-                                        target: "publicationresults",
-                                        valuePath: "state"
-                                    },
                                     seriesname_ref: {
                                         key: 'seriesname_ref',
                                         type: 'REVISIONABLE',
@@ -413,14 +408,13 @@ define(function (require) {
                                     }
                                 },
                                 fields: {
-
                                     publicationresults: {
                                         type: "REFERENCECONTAINER",
                                         reference: "publicationresults_ref",
+                                        fixedOrder: true,
                                         subfields: [
                                             "publicationresultspublicationid",
-                                            "publicationresultspublicationtitle",
-                                            "publicationresultsstate"
+                                            "publicationresultspublicationtitle"
                                         ]
                                     },
                                     publicationresultspublicationid: {
@@ -435,13 +429,6 @@ define(function (require) {
                                         type: "REFERENCE",
                                         reference: "publicationresultspublicationtitle_ref"
                                     },
-                                    publicationresultsstate: {
-                                        key: "publicationresultsstate",
-                                        subfield: true,
-                                        type: "REFERENCE",
-                                        reference: "publicationresultsstate_ref"
-                                    },
-
                                     publicationid: {
                                         type: 'STRING'
                                     },

--- a/metka/src/main/webapp/resources/js/modules/pages/study.js
+++ b/metka/src/main/webapp/resources/js/modules/pages/study.js
@@ -941,6 +941,7 @@ define(function (require) {
                                         studyerrors: {
                                             type: "REFERENCECONTAINER",
                                             reference: "studyerrors_ref",
+                                            fixedOrder: true,
                                             subfields: [
                                                 "studyerrorsstudyid",
                                                 "studyerrorsstudytitle",
@@ -950,6 +951,7 @@ define(function (require) {
                                         studyresults: {
                                             type: "REFERENCECONTAINER",
                                             reference: "studyresults_ref",
+                                            fixedOrder: true,
                                             subfields: [
                                                 "studyresultsid",
                                                 "studyresultstitle",

--- a/metka/src/main/webapp/resources/js/modules/pages/study_variables.js
+++ b/metka/src/main/webapp/resources/js/modules/pages/study_variables.js
@@ -185,6 +185,7 @@ define(function (require) {
                             key: "variableslist",
                             type: "REFERENCECONTAINER",
                             reference: "variables_ref",
+                            fixedOrder: true,
                             subfields: [
                                 "variablesstudyid",
                                 "variablesstudytitle",
@@ -226,6 +227,7 @@ define(function (require) {
                             key: "variablelist",
                             type: "REFERENCECONTAINER",
                             reference: "variable_ref",
+                            fixedOrder: true,
                             subfields: [
                                 "variablestudyid",
                                 "variablestudytitle",


### PR DESCRIPTION
Add fixedOrder: true for searchresults missing them, and remove few unnecessary lines from publication.js.